### PR TITLE
Add ability to customize empty state message

### DIFF
--- a/crispy_formset_modal/layout.py
+++ b/crispy_formset_modal/layout.py
@@ -127,6 +127,9 @@ class ModalEditFormsetLayout(LayoutObject):
                 "modal_template_name": (
                     f"crispy_formset_modal/{template_pack}/modal.html"
                 ),
+                "empty_state_template_name": (
+                    f"crispy_formset_modal/{template_pack}/empty_state.html"
+                ),
                 "template_pack": template_pack,
                 "modal_size": self.modal_size,
                 "modal_placement": self.modal_placement,

--- a/crispy_formset_modal/templates/crispy_formset_modal/bootstrap4/empty_state.html
+++ b/crispy_formset_modal/templates/crispy_formset_modal/bootstrap4/empty_state.html
@@ -1,0 +1,3 @@
+{% load i18n %}
+
+{% trans "No data" %}

--- a/crispy_formset_modal/templates/crispy_formset_modal/bootstrap4/table.html
+++ b/crispy_formset_modal/templates/crispy_formset_modal/bootstrap4/table.html
@@ -50,7 +50,7 @@
             <tbody>  
                 <tr class="empty-table">
                     <td class="empty-table-content text-center" colspan={{ headers|length|add:3 }}>
-                       {% trans "No data" %}   
+                       {% include empty_state_template_name %}
                     </td>
                 </tr>
             </tbody>

--- a/crispy_formset_modal/templates/crispy_formset_modal/bootstrap5/empty_state.html
+++ b/crispy_formset_modal/templates/crispy_formset_modal/bootstrap5/empty_state.html
@@ -1,0 +1,3 @@
+{% load i18n %}
+
+{% trans "No data" %}

--- a/crispy_formset_modal/templates/crispy_formset_modal/bootstrap5/table.html
+++ b/crispy_formset_modal/templates/crispy_formset_modal/bootstrap5/table.html
@@ -50,7 +50,7 @@
             <tbody>  
                 <tr class="empty-table">
                     <td class="empty-table-content text-center" colspan={{ headers|length|add:3 }}>
-                       {% trans "No data" %}   
+                        {% include empty_state_template_name %}
                     </td>
                 </tr>
             </tbody>

--- a/crispy_formset_modal/templates/crispy_formset_modal/bulma/empty_state.html
+++ b/crispy_formset_modal/templates/crispy_formset_modal/bulma/empty_state.html
@@ -1,0 +1,3 @@
+{% load i18n %}
+
+{% trans "No data" %}

--- a/crispy_formset_modal/templates/crispy_formset_modal/bulma/table.html
+++ b/crispy_formset_modal/templates/crispy_formset_modal/bulma/table.html
@@ -50,7 +50,7 @@
             <tbody>  
                 <tr class="empty-table">
                     <td class="empty-table-content has-text-centered" colspan={{ headers|length|add:3 }}>
-                       {% trans "No data" %}   
+                        {% include empty_state_template_name %}
                     </td>
                 </tr>
             </tbody>

--- a/crispy_formset_modal/templates/crispy_formset_modal/tailwind/empty_state.html
+++ b/crispy_formset_modal/templates/crispy_formset_modal/tailwind/empty_state.html
@@ -1,0 +1,3 @@
+{% load i18n %}
+
+{% trans "No data" %}

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -69,8 +69,9 @@ Django Crispy Formset Modal uses several templates to render formsets and modals
 * `modal.html`: This template is used to render the modal dialog for adding/editing formset instances.
 * `table.html`: This template is used to render the HTML table that displays the formset data.
 * `edit_button.html`: This template is used to render the record edit button in the formset table.
+* `empty_state.html`: This template is used to render the empty state message when there are no records in the formset.
 
-To override these templates, create a directory named `crispy_formset_modal` and a subdirectory named as per the template pack you're using (for instance, `bootstrap4`) in your project's templates directory. Then create your custom versions of `form.html`, `modal.html`, `edit_button.html`, and/or `table.html` in this directory.
+To override these templates, create a directory named `crispy_formset_modal` and a subdirectory named as per the template pack you're using (for instance, `bootstrap4`) in your project's templates directory. Then create your custom versions of `form.html`, `modal.html`, `edit_button.html`, `empty_estate.html`  and/or `table.html` in this directory.
 
 With these customization options, you can modify Django Crispy Formset Modal to better suit the needs of your project. In the next section, we'll discuss how to troubleshoot common issues and where to seek further assistance.
 


### PR DESCRIPTION
This Pull Request adds the ability for users to define a custom empty state message by overriding the templates located within `crispy_formset_modal/[template_pack]/empty_state.html`. The `template_pack`  can be `bootstrap4`, `bootstrap5`, `tailwind`, or `bulma`. Developers can override this template and introduce their own HTML code for the empty state message.