### PR TITLE
Django Autocomplete Light compatibility fix

### DIFF
--- a/js/src/utils.js
+++ b/js/src/utils.js
@@ -28,7 +28,11 @@ export function getTextValue(el) {
   let textValue = "";
   if (type === "select") {
     let tempDiv = document.createElement("div");
+    if (el.options[el.selectedIndex]) {
     tempDiv.innerHTML = el.options[el.selectedIndex].innerText;
+    } else {
+        tempDiv.innerHTML = "-------";
+    }
     textValue = tempDiv.innerText
       .split("\n")
       .map((item) => item.trim())


### PR DESCRIPTION
 * Django Autocomplete Light doesn't have a value for unselected fields.
 * Opening a modal containing a DAL field causes "Cannot read properties of undefined (reading 'innerText')" error and breaks further actions.